### PR TITLE
Limit player camera pitch to prevent flipping

### DIFF
--- a/scenes/player/CameraPivot.cs
+++ b/scenes/player/CameraPivot.cs
@@ -9,7 +9,7 @@ public partial class CameraPivot : Marker3D
   // 0 = looking straight ahead (horizon)
   // Negative values = looking up, Positive values = looking down
   [Export]
-  public float MinPitch { get; set; } = -Mathf.Pi / 2.0f; // Looking straight up
+  public float MinPitch { get; set; } = -1.2f; // Limit upward rotation to ~69 degrees to prevent flipping
 
   [Export]
   public float MaxPitch { get; set; } = 0.3f; // Can look down a bit, but not too far below the world


### PR DESCRIPTION
This PR limits the player camera's upward pitch so it can no longer flip over the boat.

**Change**
- Update `CameraPivot.MinPitch` from `-Mathf.Pi / 2.0f` (-90°) to `-1.2f` (~-69°) so the camera cannot rotate far enough to go upside down.

**Details**
- File: `scenes/player/CameraPivot.cs`
- The camera still allows a generous upward look angle but stops well before flipping over the top.

**Testing**
- Verified that only `CameraPivot.cs` was modified.
- No existing automated test suite was detected (no `*Test*.cs` files within depth 4), so this change was validated by code review only.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author