### PR TITLE
Add server AI debug menu with zoom and debug toggles

### DIFF
--- a/godot/scenes/ai_debug_menu/AiDebugMenu.cs
+++ b/godot/scenes/ai_debug_menu/AiDebugMenu.cs
@@ -1,0 +1,241 @@
+namespace PiratesQuest;
+
+using Godot;
+using System.Collections.Generic;
+
+public partial class AiDebugMenu : CanvasLayer
+{
+  private const float ListRefreshSeconds = 1.0f;
+  private const float ZoomInFactor = 0.6f;
+  private const float MinCameraDistanceFromShip = 12.0f;
+  private const int ListPanelWidth = 320;
+  private const int DetailPanelWidth = 380;
+
+  private VBoxContainer _shipList;
+  private Label _detailLabel;
+  private Button _zoomInButton;
+  private AiShip _selectedShip;
+  private readonly Dictionary<AiShip, Button> _rows = new();
+
+  public override void _Ready()
+  {
+    if (!Multiplayer.IsServer())
+    {
+      QueueFree();
+      return;
+    }
+
+    Layer = 100;
+    BuildUi();
+
+    var listTimer = new Timer { WaitTime = ListRefreshSeconds, Autostart = true };
+    listTimer.Timeout += RefreshShipList;
+    AddChild(listTimer);
+
+    RefreshShipList();
+  }
+
+  private void BuildUi()
+  {
+    var listPanel = new PanelContainer();
+    AddChild(listPanel);
+    listPanel.AnchorLeft = 1.0f;
+    listPanel.AnchorRight = 1.0f;
+    listPanel.AnchorTop = 0.0f;
+    listPanel.AnchorBottom = 1.0f;
+    listPanel.OffsetLeft = -ListPanelWidth;
+    listPanel.OffsetRight = 0;
+    listPanel.OffsetTop = 0;
+    listPanel.OffsetBottom = 0;
+
+    var listScroll = new ScrollContainer
+    {
+      HorizontalScrollMode = ScrollContainer.ScrollMode.Disabled,
+    };
+    listPanel.AddChild(listScroll);
+
+    _shipList = new VBoxContainer
+    {
+      SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+    };
+    listScroll.AddChild(_shipList);
+
+    var header = new Label { Text = "AI Ships (server)" };
+    _shipList.AddChild(header);
+
+    var detailPanel = new PanelContainer();
+    AddChild(detailPanel);
+    detailPanel.AnchorLeft = 0.0f;
+    detailPanel.AnchorRight = 0.0f;
+    detailPanel.AnchorTop = 0.0f;
+    detailPanel.AnchorBottom = 1.0f;
+    detailPanel.OffsetLeft = 0;
+    detailPanel.OffsetRight = DetailPanelWidth;
+    detailPanel.OffsetTop = 0;
+    detailPanel.OffsetBottom = 0;
+
+    var margin = new MarginContainer();
+    margin.AddThemeConstantOverride("margin_left", 12);
+    margin.AddThemeConstantOverride("margin_right", 12);
+    margin.AddThemeConstantOverride("margin_top", 12);
+    margin.AddThemeConstantOverride("margin_bottom", 12);
+    detailPanel.AddChild(margin);
+
+    var detailLayout = new VBoxContainer
+    {
+      SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+    };
+    detailLayout.AddThemeConstantOverride("separation", 10);
+    margin.AddChild(detailLayout);
+
+    _zoomInButton = new Button
+    {
+      Text = "Zoom In On Selected Ship",
+      Disabled = true,
+    };
+    _zoomInButton.Pressed += ZoomInOnSelectedShip;
+    detailLayout.AddChild(_zoomInButton);
+
+    _detailLabel = new Label
+    {
+      Text = "No ship selected",
+      AutowrapMode = TextServer.AutowrapMode.WordSmart,
+      VerticalAlignment = VerticalAlignment.Top,
+      SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+    };
+    detailLayout.AddChild(_detailLabel);
+  }
+
+  public override void _Process(double delta)
+  {
+    if (!IsInstanceValid(_selectedShip))
+    {
+      if (_selectedShip != null)
+      {
+        _selectedShip = null;
+        _detailLabel.Text = "No ship selected";
+        UpdateRowHighlights();
+      }
+      return;
+    }
+
+    var p = _selectedShip.GlobalPosition;
+    var r = _selectedShip.Rotation;
+    _detailLabel.Text = string.Join('\n', [
+      $"Node: {_selectedShip.Name}",
+      $"Pos: ({p.X:0.0}, {p.Y:0.0}, {p.Z:0.0})",
+      $"Rot: ({Mathf.RadToDeg(r.X):0.0}°, {Mathf.RadToDeg(r.Y):0.0}°, {Mathf.RadToDeg(r.Z):0.0}°)",
+      $"Ally: {_selectedShip.AllyTypeId}",
+      string.Empty,
+      _selectedShip.BuildDebugText(),
+    ]);
+  }
+
+  private void RefreshShipList()
+  {
+    var nodes = GetTree().GetNodesInGroup("ai_ships");
+
+    var live = new HashSet<AiShip>();
+    foreach (var node in nodes)
+    {
+      if (node is AiShip ship && IsInstanceValid(ship))
+      {
+        live.Add(ship);
+      }
+    }
+
+    var toRemove = new List<AiShip>();
+    foreach (var entry in _rows)
+    {
+      if (!live.Contains(entry.Key))
+      {
+        toRemove.Add(entry.Key);
+      }
+    }
+    foreach (var ship in toRemove)
+    {
+      _rows[ship].QueueFree();
+      _rows.Remove(ship);
+    }
+
+    foreach (var ship in live)
+    {
+      if (_rows.ContainsKey(ship)) continue;
+
+      var button = new Button
+      {
+        Text = FormatRow(ship),
+        Alignment = HorizontalAlignment.Left,
+      };
+      var captured = ship;
+      button.Pressed += () =>
+      {
+        _selectedShip = captured;
+        UpdateRowHighlights();
+      };
+      _shipList.AddChild(button);
+      _rows[ship] = button;
+    }
+
+    foreach (var entry in _rows)
+    {
+      entry.Value.Text = FormatRow(entry.Key);
+    }
+
+    UpdateRowHighlights();
+  }
+
+  private static string FormatRow(AiShip ship)
+  {
+    return $"{ship.DisplayName} [{ship.ArchetypeId}] HP {ship.Health}/{ship.MaxHealth}";
+  }
+
+  private void UpdateRowHighlights()
+  {
+    foreach (var entry in _rows)
+    {
+      bool isSelected = entry.Key == _selectedShip;
+      entry.Value.Modulate = isSelected ? new Color(1.0f, 0.85f, 0.4f) : Colors.White;
+    }
+
+    if (_zoomInButton != null)
+    {
+      _zoomInButton.Disabled = !IsInstanceValid(_selectedShip);
+    }
+  }
+
+  private void ZoomInOnSelectedShip()
+  {
+    if (!IsInstanceValid(_selectedShip))
+    {
+      _detailLabel.Text = "No ship selected";
+      UpdateRowHighlights();
+      return;
+    }
+
+    // In server mode this is the active FreeCam. We still fetch the active camera
+    // from the viewport so the debug menu works even if that setup changes later.
+    var camera = GetViewport()?.GetCamera3D();
+    if (camera == null)
+    {
+      GD.PrintErr("AI Debug Menu: cannot zoom - no active camera found.");
+      return;
+    }
+
+    Vector3 shipPosition = _selectedShip.GlobalPosition;
+    Vector3 shipToCamera = camera.GlobalPosition - shipPosition;
+
+    // If the camera is exactly on the ship, pick a stable fallback direction.
+    if (shipToCamera.LengthSquared() < 0.0001f)
+    {
+      shipToCamera = (_selectedShip.GlobalBasis.Z + (Vector3.Up * 0.35f)).Normalized();
+    }
+
+    float currentDistance = shipToCamera.Length();
+    float nextDistance = Mathf.Max(MinCameraDistanceFromShip, currentDistance * ZoomInFactor);
+    Vector3 directionFromShip = shipToCamera.Normalized();
+
+    camera.GlobalPosition = shipPosition + (directionFromShip * nextDistance);
+    camera.LookAt(shipPosition, Vector3.Up);
+  }
+}

--- a/godot/scenes/ai_debug_menu/AiDebugMenu.cs
+++ b/godot/scenes/ai_debug_menu/AiDebugMenu.cs
@@ -13,6 +13,8 @@ public partial class AiDebugMenu : CanvasLayer
 
   private VBoxContainer _shipList;
   private Label _detailLabel;
+  private Button _enableDebugButton;
+  private Button _enableNavigationDebugButton;
   private Button _zoomInButton;
   private AiShip _selectedShip;
   private readonly Dictionary<AiShip, Button> _rows = new();
@@ -96,6 +98,22 @@ public partial class AiDebugMenu : CanvasLayer
     _zoomInButton.Pressed += ZoomInOnSelectedShip;
     detailLayout.AddChild(_zoomInButton);
 
+    _enableDebugButton = new Button
+    {
+      Text = "Enable Debug On Selected Ship",
+      Disabled = true,
+    };
+    _enableDebugButton.Pressed += EnableDebugOnSelectedShip;
+    detailLayout.AddChild(_enableDebugButton);
+
+    _enableNavigationDebugButton = new Button
+    {
+      Text = "Enable Rays + Patrol On Selected Ship",
+      Disabled = true,
+    };
+    _enableNavigationDebugButton.Pressed += EnableNavigationDebugOnSelectedShip;
+    detailLayout.AddChild(_enableNavigationDebugButton);
+
     _detailLabel = new Label
     {
       Text = "No ship selected",
@@ -126,6 +144,8 @@ public partial class AiDebugMenu : CanvasLayer
       $"Pos: ({p.X:0.0}, {p.Y:0.0}, {p.Z:0.0})",
       $"Rot: ({Mathf.RadToDeg(r.X):0.0}°, {Mathf.RadToDeg(r.Y):0.0}°, {Mathf.RadToDeg(r.Z):0.0}°)",
       $"Ally: {_selectedShip.AllyTypeId}",
+      $"Debug: {(_selectedShip.IsDebugEnabled ? "On" : "Off")}",
+      $"Nav Debug: {(_selectedShip.IsNavigationDebugEnabled ? "On" : "Off")}",
       string.Empty,
       _selectedShip.BuildDebugText(),
     ]);
@@ -202,6 +222,30 @@ public partial class AiDebugMenu : CanvasLayer
     {
       _zoomInButton.Disabled = !IsInstanceValid(_selectedShip);
     }
+
+    if (_enableDebugButton != null)
+    {
+      bool hasSelectedShip = IsInstanceValid(_selectedShip);
+      bool canEnable = hasSelectedShip && !_selectedShip.IsDebugEnabled;
+      _enableDebugButton.Disabled = !canEnable;
+      _enableDebugButton.Text = !hasSelectedShip
+        ? "Select A Ship To Enable Debug"
+        : canEnable
+          ? "Enable Debug On Selected Ship"
+          : "Debug Already Enabled";
+    }
+
+    if (_enableNavigationDebugButton != null)
+    {
+      bool hasSelectedShip = IsInstanceValid(_selectedShip);
+      bool canEnable = hasSelectedShip && !_selectedShip.IsNavigationDebugEnabled;
+      _enableNavigationDebugButton.Disabled = !canEnable;
+      _enableNavigationDebugButton.Text = !hasSelectedShip
+        ? "Select A Ship To Enable Rays + Patrol"
+        : canEnable
+          ? "Enable Rays + Patrol On Selected Ship"
+          : "Rays + Patrol Already Enabled";
+    }
   }
 
   private void ZoomInOnSelectedShip()
@@ -237,5 +281,31 @@ public partial class AiDebugMenu : CanvasLayer
 
     camera.GlobalPosition = shipPosition + (directionFromShip * nextDistance);
     camera.LookAt(shipPosition, Vector3.Up);
+  }
+
+  private void EnableDebugOnSelectedShip()
+  {
+    if (!IsInstanceValid(_selectedShip))
+    {
+      _detailLabel.Text = "No ship selected";
+      UpdateRowHighlights();
+      return;
+    }
+
+    _selectedShip.SetDebugEnabled(true);
+    UpdateRowHighlights();
+  }
+
+  private void EnableNavigationDebugOnSelectedShip()
+  {
+    if (!IsInstanceValid(_selectedShip))
+    {
+      _detailLabel.Text = "No ship selected";
+      UpdateRowHighlights();
+      return;
+    }
+
+    _selectedShip.SetNavigationDebugEnabled(true);
+    UpdateRowHighlights();
   }
 }

--- a/godot/scenes/ai_debug_menu/AiDebugMenu.cs.uid
+++ b/godot/scenes/ai_debug_menu/AiDebugMenu.cs.uid
@@ -1,0 +1,1 @@
+uid://1tf06qvmnrvl

--- a/godot/scenes/ai_debug_menu/ai_debug_menu.tscn
+++ b/godot/scenes/ai_debug_menu/ai_debug_menu.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/ai_debug_menu/AiDebugMenu.cs" id="1_aidbg"]
+
+[node name="AiDebugMenu" type="CanvasLayer"]
+script = ExtResource("1_aidbg")

--- a/godot/scenes/ai_ship/AiShip.cs
+++ b/godot/scenes/ai_ship/AiShip.cs
@@ -519,7 +519,7 @@ public partial class AiShip : CharacterBody3D, IDamageable
       _stateDebugLabel.Text = BuildDebugText();
   }
 
-  private string BuildDebugText()
+  public string BuildDebugText()
   {
     string targetText = _debugHasTargetShip
       ? $"Ship {_debugDistanceToTargetShip:0.0}"

--- a/godot/scenes/ai_ship/AiShip.cs
+++ b/godot/scenes/ai_ship/AiShip.cs
@@ -37,6 +37,8 @@ public partial class AiShip : CharacterBody3D, IDamageable
   public int MaxHealth => Mathf.RoundToInt(_definition.MaxHealth);
   public string ArchetypeId => _definition.Id;
   public string AllyTypeId => _definition.AllyTypeId;
+  public bool IsDebugEnabled => _debugEnabled;
+  public bool IsNavigationDebugEnabled => _navigationDebugEnabled;
 
   private AiShipDefinition _definition = AiShipDefinition.FromId("raider");
   private IAiShipController _controller;
@@ -63,6 +65,7 @@ public partial class AiShip : CharacterBody3D, IDamageable
   private float _escapeTurnDirection = 1.0f;
   private bool _isSinking = false;
   private bool _debugEnabled = false;
+  private bool _navigationDebugEnabled = false;
   private string _debugState = string.Empty;
   private bool _debugHasTargetShip = false;
   private float _debugDistanceToTargetShip = 0.0f;
@@ -70,7 +73,9 @@ public partial class AiShip : CharacterBody3D, IDamageable
   private bool _debugLeftBlocked = false;
   private bool _debugRightBlocked = false;
   private FloatingBody3D _floatingBody;
+  private MeshInstance3D _patrolPointDebugMarker;
   private Label3D _stateDebugLabel;
+  private readonly List<RayDebugVisual> _rayDebugVisuals = new();
 
   private const float RecoilRollAmount = 0.32f;
   private const float RecoilDecaySpeed = 2.4f;
@@ -81,7 +86,25 @@ public partial class AiShip : CharacterBody3D, IDamageable
   private const float StuckAreaKillSeconds = 10.0f;
   private const float StuckAreaClearResetSeconds = 1.5f;
   private const float LifetimeRespawnSeconds = 1800.0f;
+  private const string HunterPatrolPointMemoryKey = "hunter.patrol_point";
+  private static readonly Color DebugRayBlockedColor = new(1.0f, 0.34f, 0.24f, 1.0f);
+  private static readonly Color DebugRayClearColor = new(0.2f, 0.95f, 0.66f, 1.0f);
   private static readonly Vector3 DebugLabelOffset = new(0.0f, 7.0f, 0.0f);
+  private static readonly Vector3 DebugMarkerHeightOffset = new(0.0f, 1.2f, 0.0f);
+
+  private sealed class RayDebugVisual
+  {
+    public RayCast3D Ray { get; }
+    public MeshInstance3D Mesh { get; }
+    public StandardMaterial3D Material { get; }
+
+    public RayDebugVisual(RayCast3D ray, MeshInstance3D mesh, StandardMaterial3D material)
+    {
+      Ray = ray;
+      Mesh = mesh;
+      Material = material;
+    }
+  }
 
   public override void _Ready()
   {
@@ -483,31 +506,107 @@ public partial class AiShip : CharacterBody3D, IDamageable
     if (!IsInsideTree())
       return;
 
-    bool shouldShowDebug = _debugEnabled && Multiplayer.IsServer();
+    bool isServer = Multiplayer.IsServer();
+    bool shouldShowStateDebug = _debugEnabled && isServer;
+    bool shouldShowNavigationDebug = _navigationDebugEnabled && isServer;
 
-    if (!shouldShowDebug)
+    if (!shouldShowStateDebug)
     {
-      CleanupDebugVisuals();
-      return;
+      CleanupStateDebugVisuals();
     }
-
-    if (_stateDebugLabel == null)
+    else if (_stateDebugLabel == null)
     {
       _stateDebugLabel = AiDebugVisuals.CreateStateLabel("AiStateDebugLabel", DebugLabelOffset);
       AddChild(_stateDebugLabel);
     }
+
+    if (!shouldShowNavigationDebug)
+    {
+      CleanupNavigationDebugVisuals();
+    }
+    else
+    {
+      EnsureNavigationDebugVisuals();
+    }
   }
 
   private void CleanupDebugVisuals()
+  {
+    CleanupStateDebugVisuals();
+    CleanupNavigationDebugVisuals();
+  }
+
+  private void CleanupStateDebugVisuals()
   {
     if (IsInstanceValid(_stateDebugLabel))
       _stateDebugLabel.QueueFree();
     _stateDebugLabel = null;
   }
 
+  private void CleanupNavigationDebugVisuals()
+  {
+    if (IsInstanceValid(_patrolPointDebugMarker))
+      _patrolPointDebugMarker.QueueFree();
+    _patrolPointDebugMarker = null;
+
+    foreach (RayDebugVisual rayDebug in _rayDebugVisuals)
+    {
+      if (IsInstanceValid(rayDebug.Mesh))
+        rayDebug.Mesh.QueueFree();
+    }
+    _rayDebugVisuals.Clear();
+  }
+
+  private void EnsureNavigationDebugVisuals()
+  {
+    if (_patrolPointDebugMarker == null)
+    {
+      _patrolPointDebugMarker = AiDebugVisuals.CreatePointMarker(
+        "PatrolPointDebugMarker",
+        new Color(0.25f, 0.95f, 0.65f),
+        radius: 0.8f
+      );
+      GetTree().CurrentScene?.AddChild(_patrolPointDebugMarker);
+    }
+
+    if (_rayDebugVisuals.Count == 0)
+    {
+      TryCreateRayDebugVisual("ForwardRayDebug", ForwardRay);
+      TryCreateRayDebugVisual("ForwardLeftRayDebug", ForwardLeftRay);
+      TryCreateRayDebugVisual("ForwardRightRayDebug", ForwardRightRay);
+      TryCreateRayDebugVisual("WideLeftRayDebug", WideLeftRay);
+      TryCreateRayDebugVisual("WideRightRayDebug", WideRightRay);
+    }
+  }
+
+  private void TryCreateRayDebugVisual(string name, RayCast3D ray)
+  {
+    if (ray == null)
+      return;
+
+    var material = new StandardMaterial3D
+    {
+      AlbedoColor = DebugRayClearColor,
+      ShadingMode = BaseMaterial3D.ShadingModeEnum.Unshaded,
+      Transparency = BaseMaterial3D.TransparencyEnum.Alpha,
+    };
+
+    var rayMesh = new MeshInstance3D
+    {
+      Name = name,
+      TopLevel = true,
+      Mesh = new ImmediateMesh(),
+      MaterialOverride = material,
+      CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
+    };
+    GetTree().CurrentScene?.AddChild(rayMesh);
+
+    _rayDebugVisuals.Add(new RayDebugVisual(ray, rayMesh, material));
+  }
+
   private void UpdateDebugVisuals()
   {
-    if (!_debugEnabled || !Multiplayer.IsServer())
+    if (!Multiplayer.IsServer())
       return;
 
     if (!IsInsideTree())
@@ -515,8 +614,81 @@ public partial class AiShip : CharacterBody3D, IDamageable
 
     RefreshDebugVisuals();
 
-    if (_stateDebugLabel != null)
+    if (_debugEnabled && _stateDebugLabel != null)
       _stateDebugLabel.Text = BuildDebugText();
+
+    if (_navigationDebugEnabled)
+      UpdateNavigationDebugVisuals();
+  }
+
+  private void UpdateNavigationDebugVisuals()
+  {
+    if (_memory.TryGet<Vector3>(HunterPatrolPointMemoryKey, out Vector3 patrolPoint))
+    {
+      if (_patrolPointDebugMarker != null)
+      {
+        _patrolPointDebugMarker.Visible = true;
+        _patrolPointDebugMarker.GlobalPosition = patrolPoint + DebugMarkerHeightOffset;
+      }
+    }
+    else if (_patrolPointDebugMarker != null)
+    {
+      _patrolPointDebugMarker.Visible = false;
+    }
+
+    foreach (RayDebugVisual rayDebug in _rayDebugVisuals)
+    {
+      UpdateRayDebugVisual(rayDebug);
+    }
+  }
+
+  private static void UpdateRayDebugVisual(RayDebugVisual rayDebug)
+  {
+    if (!IsInstanceValid(rayDebug.Ray) || !IsInstanceValid(rayDebug.Mesh))
+      return;
+
+    Vector3 start = rayDebug.Ray.GlobalPosition;
+    bool blocked = rayDebug.Ray.IsColliding();
+    Vector3 end = blocked
+      ? rayDebug.Ray.GetCollisionPoint()
+      : rayDebug.Ray.ToGlobal(rayDebug.Ray.TargetPosition);
+
+    rayDebug.Material.AlbedoColor = blocked ? DebugRayBlockedColor : DebugRayClearColor;
+
+    if (rayDebug.Mesh.Mesh is not ImmediateMesh lineMesh)
+      return;
+
+    lineMesh.ClearSurfaces();
+    lineMesh.SurfaceBegin(Mesh.PrimitiveType.Lines);
+    lineMesh.SurfaceAddVertex(start);
+    lineMesh.SurfaceAddVertex(end);
+    lineMesh.SurfaceEnd();
+  }
+
+  /// <summary>
+  /// Server-side AI debug toggle used by the AI debug menu.
+  /// </summary>
+  public void SetDebugEnabled(bool enabled)
+  {
+    if (_debugEnabled == enabled)
+      return;
+
+    _debugEnabled = enabled;
+    RefreshDebugVisuals();
+    UpdateDebugVisuals();
+  }
+
+  /// <summary>
+  /// Server-side navigation debug toggle for patrol-point and terrain-ray visuals.
+  /// </summary>
+  public void SetNavigationDebugEnabled(bool enabled)
+  {
+    if (_navigationDebugEnabled == enabled)
+      return;
+
+    _navigationDebugEnabled = enabled;
+    RefreshDebugVisuals();
+    UpdateDebugVisuals();
   }
 
   public string BuildDebugText()

--- a/godot/scenes/play/Play.cs
+++ b/godot/scenes/play/Play.cs
@@ -27,6 +27,7 @@ public partial class Play : Node3D
   private PackedScene _aiShipScene = GD.Load<PackedScene>("res://scenes/ai_ship/ai_ship.tscn");
   private PackedScene _cannonBallScene = GD.Load<PackedScene>("res://scenes/cannon_ball/cannon_ball.tscn");
   private PackedScene _deadPlayerScene = GD.Load<PackedScene>("res://scenes/dead_player/dead_player.tscn");
+  private PackedScene _aiDebugMenuScene = GD.Load<PackedScene>("res://scenes/ai_debug_menu/ai_debug_menu.tscn");
   private readonly Dictionary<long, string> _peerUsernames = new();
   private Timer _heartbeatTimer;
   private Timer _leaderboardTimer;
@@ -104,6 +105,8 @@ public partial class Play : Node3D
       StartServerHeartbeatIfNeeded();
       StartLeaderboardSyncIfNeeded();
       _aiShipManager.StartRespawnLoop();
+
+      AddChild(_aiDebugMenuScene.Instantiate());
 
       // Activate free camera in server mode
       if (Configuration.IsDesignatedServerMode() && _freeCam != null)

--- a/godot/scripts/ai/AiShipContextExtensions.cs.uid
+++ b/godot/scripts/ai/AiShipContextExtensions.cs.uid
@@ -1,0 +1,1 @@
+uid://c07er31dgk8ih

--- a/godot/scripts/ai/AiShipMemory.cs.uid
+++ b/godot/scripts/ai/AiShipMemory.cs.uid
@@ -1,0 +1,1 @@
+uid://b76nfstubvt2k

--- a/godot/scripts/ai/AiShipSensingTypes.cs.uid
+++ b/godot/scripts/ai/AiShipSensingTypes.cs.uid
@@ -1,0 +1,1 @@
+uid://dkkm5cbe7r4xb

--- a/godot/scripts/ai/hunterDeterministic/HunterAiShipControllerConfig.cs.uid
+++ b/godot/scripts/ai/hunterDeterministic/HunterAiShipControllerConfig.cs.uid
@@ -1,0 +1,1 @@
+uid://2m22cu4ecsb5

--- a/godot/scripts/ai/traderDeterministic/TraderDeterministicAiShipControllerConfig.cs.uid
+++ b/godot/scripts/ai/traderDeterministic/TraderDeterministicAiShipControllerConfig.cs.uid
@@ -1,0 +1,1 @@
+uid://b078butbhvkhn


### PR DESCRIPTION
This adds a server-only AI debug menu scene and wires it into Play so it appears only when running as server. The menu lists live AI ships, shows per-ship details, and includes a zoom-to-selected-ship camera action. It also adds per-ship debug controls from the UI, including enabling state debug text and enabling navigation debug visuals (patrol point marker plus terrain ray lines) for the selected ship. AiShip now exposes runtime debug toggle APIs used by the menu and updates/cleans these visuals safely; the branch also includes the scene/uid metadata files required for these resources.